### PR TITLE
Add a feature to regenerate the result and some minor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Completed in 0.92 seconds
 
 tar -xvzf linux-command-gpt.tar.gz 
 
-Are you sure you want to execute the command? (Y/n):
+Do you want to (e)xecute, (r)egenerate, or take (N)o action on the command? (e/r/N): 
 ```
 
 ### Options

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Or you can [download lcg executable file](https://github.com/asrul10/linux-comma
 ```bash
 > lcg I want to extract linux-command-gpt.tar.gz file
 Completed in 0.92 seconds
-┌────────────────────────────────────┐
-│ tar -xvzf linux-command-gpt.tar.gz │
-└────────────────────────────────────┘
+
+tar -xvzf linux-command-gpt.tar.gz 
+
 Are you sure you want to execute the command? (Y/n):
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/asrul/linux-command-gpt
 
 go 1.18
+
+require (
+	golang.org/x/sys v0.6.0 // indirect
+	golang.org/x/term v0.6.0 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,3 @@
 module github.com/asrul/linux-command-gpt
 
 go 1.18
-
-require (
-	golang.org/x/sys v0.6.0 // indirect
-	golang.org/x/term v0.6.0 // indirect
-)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.6.0 h1:clScbb1cHjoCkyRbWwBEUZ5H/tIFu5TAXIqaZD0Gcjw=
+golang.org/x/term v0.6.0/go.mod h1:m6U89DPEgQRMq3DNkDClhWw02AUbt2daBVO4cn4Hv9U=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,0 @@
-golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
-golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/term v0.6.0 h1:clScbb1cHjoCkyRbWwBEUZ5H/tIFu5TAXIqaZD0Gcjw=
-golang.org/x/term v0.6.0/go.mod h1:m6U89DPEgQRMq3DNkDClhWw02AUbt2daBVO4cn4Hv9U=

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/asrul/linux-command-gpt/gpt"
+	"golang.org/x/term"
 )
 
 const (
@@ -58,6 +59,10 @@ func handleCommand(cmd string) int {
 }
 
 func main() {
+	width, _, err := term.GetSize(0)
+	if err != nil {
+		panic(err)
+	}
 	currentUser, err := user.Current()
 	if err != nil {
 		panic(err)
@@ -127,9 +132,9 @@ func main() {
 	elapsed := time.Since(s).Seconds()
 	elapsed = math.Round(elapsed*100) / 100
 	fmt.Printf("Completed in %v seconds\n", elapsed)
-	fmt.Printf("┌%s┐\n", strings.Repeat("─", len(r)+2))
-	fmt.Printf("│ %s │\n", r)
-	fmt.Printf("└%s┘\n", strings.Repeat("─", len(r)+2))
+	fmt.Println(strings.Repeat("─", width))
+	fmt.Println(r)
+	fmt.Println(strings.Repeat("─", width))
 	fmt.Print("Are you sure you want to execute the command? (Y/n): ")
 	fmt.Scanln(&c)
 	if c != "Y" && c != "y" {

--- a/main.go
+++ b/main.go
@@ -124,14 +124,14 @@ func main() {
 		return
 	}
 
-	c := "Y"
+	c := "N"
 	elapsed := time.Since(s).Seconds()
 	elapsed = math.Round(elapsed*100) / 100
 	fmt.Printf("Completed in %v seconds\n\n", elapsed)
 	fmt.Println(r)
-	fmt.Print("\nAre you sure you want to execute the command? (Y/n): ")
+	fmt.Print("\nAre you sure you want to execute the command? (y/N): ")
 	fmt.Scanln(&c)
-	if c != "Y" && c != "y" {
+	if c == "N" || c == "n" {
 		return
 	}
 

--- a/main.go
+++ b/main.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/asrul/linux-command-gpt/gpt"
-	"golang.org/x/term"
 )
 
 const (
@@ -59,10 +58,6 @@ func handleCommand(cmd string) int {
 }
 
 func main() {
-	width, _, err := term.GetSize(0)
-	if err != nil {
-		panic(err)
-	}
 	currentUser, err := user.Current()
 	if err != nil {
 		panic(err)
@@ -131,11 +126,9 @@ func main() {
 	c := "Y"
 	elapsed := time.Since(s).Seconds()
 	elapsed = math.Round(elapsed*100) / 100
-	fmt.Printf("Completed in %v seconds\n", elapsed)
-	fmt.Println(strings.Repeat("─", width))
+	fmt.Printf("Completed in %v seconds\n\n", elapsed)
 	fmt.Println(r)
-	fmt.Println(strings.Repeat("─", width))
-	fmt.Print("Are you sure you want to execute the command? (Y/n): ")
+	fmt.Print("\nAre you sure you want to execute the command? (Y/n): ")
 	fmt.Scanln(&c)
 	if c != "Y" && c != "y" {
 		return

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ Usage: lcg [options]
   --update-key   update the API key
   --delete-key   delete the API key
 
+Example Usage: lcg I want to extract linux-command-gpt.tar.gz file
   `
 
 	VERSION        = "0.1.0"

--- a/main.go
+++ b/main.go
@@ -34,7 +34,7 @@ Usage: lcg [options]
 Example Usage: lcg I want to extract linux-command-gpt.tar.gz file
   `
 
-	VERSION        = "0.1.0"
+	VERSION        = "0.1.3"
 	CMD_HELP       = 100
 	CMD_VERSION    = 101
 	CMD_UPDATE     = 102


### PR DESCRIPTION
- [x] There will be three options after getting the result: (e)xecute, (r)egenerate, and (N)o action.
- [x] The default option will be (N)o action instead of (e)xecute.
- [x] Remove the box surrounding the result to make it easier to select and copy the command.
- [x] Show example usage if there is no option

This pull request addresses issue #5 #7 